### PR TITLE
Priority field for MX records in FastDNS to Integer

### DIFF
--- a/akamai/resource_akamai_fastdns_zone.go
+++ b/akamai/resource_akamai_fastdns_zone.go
@@ -274,7 +274,7 @@ func resourceFastDNSZone() *schema.Resource {
 							Required: true,
 						},
 						"priority": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeInt,
 							Required: true,
 						},
 					},


### PR DESCRIPTION
- priority field for FastDNS records should be read as int
- changed priority field in schema from string to int.